### PR TITLE
appending chartname to nginx-conf

### DIFF
--- a/charts/templates/nginxconf.yaml
+++ b/charts/templates/nginxconf.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nginx-conf
+  name: {{ .Chart.Name }}-nginx-conf
 data:
 {{ tpl (.Files.Glob "files/*").AsConfig . | indent 2 }}


### PR DESCRIPTION
Appending chartname to nginx-conf to allow for each chart to have its own nginx configs