### PR TITLE
Update chart.yaml kube version

### DIFF
--- a/charts/ui-plugin-server/Chart.yaml
+++ b/charts/ui-plugin-server/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows


### PR DESCRIPTION
Updating the max kube version in `catalog.cattle.io/kube-version`so that we don't need to change this again and again when building an extension (the new "standard" in Rancher v2.7.2 is v1.25 and with the current config the extensions aren't loaded on the UI).

Facing this problem when building the `Elemental` and `Kubewarden` extensions